### PR TITLE
add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Skeet Next.js(React) - Firestore",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers-contrib/features/firebase-cli:2": {},
+		"ghcr.io/dhoeric/features/google-cloud-cli:1": {},
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sudo npm i -g @skeet-framework/cli",
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"dsznajder.es7-react-js-snippets",
+				"bradlc.vscode-tailwindcss",
+				"esbenp.prettier-vscode",
+				"dbaeumer.vscode-eslint"
+			]
+		}
+	}
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
This devcontainer include skeet required Packages.

If you agree, please approve.

```
node ➜ /workspaces/next-dev $ java -version
openjdk version "17.0.8.1" 2023-08-24
OpenJDK Runtime Environment Temurin-17.0.8.1+1 (build 17.0.8.1+1)
OpenJDK 64-Bit Server VM Temurin-17.0.8.1+1 (build 17.0.8.1+1, mixed mode, sharing)
node ➜ /workspaces/next-dev $ gcloud --version
Google Cloud SDK 449.0.0
alpha 2023.10.02
beta 2023.10.02
bq 2.0.98
bundled-python3-unix 3.9.16
core 2023.10.02
gcloud-crc32c 1.0.0
gsutil 5.26
node ➜ /workspaces/next-dev $ firebase --version
12.6.1
node ➜ /workspaces/next-dev $ node --version
v18.18.0
node ➜ /workspaces/next-dev $ yarn --version
1.22.19
node ➜ /workspaces/next-dev $ gh --version
gh version 2.36.0 (2023-10-03)
https://github.com/cli/cli/releases/tag/v2.36.0
```

##  Resolved Issues
- close #87  

## Details of Changes
- [x] Add devcontainer.json

