### PR TITLE
update node version in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Skeet Next.js(React) - Firestore",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
 	"features": {
 		"ghcr.io/devcontainers/features/java:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},


### PR DESCRIPTION
node support version of skeet-next has been increased to 20.3.1 or higher
version of the node in the devcontainer has also been increased.
20.3.1 was not in the devcontainer image, it is now 20.9.0. 

````
$ node --version v20.9.0
````